### PR TITLE
Add MedSci Skills to Workflow & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Systematic methods for identifying, evaluating, and integrating research evidenc
 - [LLAssist](https://arxiv.org/abs/2407.13993) - Provides simple tools for automating literature reviews by leveraging Large Language Models and Natural Language Processing to extract information and evaluate relevance.
 - [ProfOlaf](https://arxiv.org/abs/2510.26750v2) - An open-source semi-automated tool designed to support systematic literature reviews by assisting in study selection and organization. 
 - [LatteReview](https://pouriarouzrokh.github.io/LatteReview/) - An open-source multi-agent framework designed to automate systematic review workflows using large language models.
-- [MedSci Skills](https://github.com/Aperivue/medsci-skills) - Open-source (MIT) Claude Code agent-skill suite for the medical research lifecycle: PubMed/CrossRef-verified reference checking, EQUATOR reporting-guideline and risk-of-bias auditing (PRISMA, STARD, QUADAS-2, ROBINS-I, and others), DTA and intervention meta-analysis synthesis, and PRISMA flow-diagram generation.
+- [MedSci Skills](https://github.com/Aperivue/medsci-skills) - Open-source MIT Claude Code skill suite for medical research and evidence synthesis: literature verification, PRISMA workflows, risk-of-bias auditing, and meta-analysis automation.
 - [EvidenceSynthesis](https://ohdsi.github.io/EvidenceSynthesis/) - Contains routines for combining causal effect estimates and study diagnostics across multiple data sites in a distributed study using meta-analysis.
 
 ## Visualization & Reporting

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Systematic methods for identifying, evaluating, and integrating research evidenc
 - [LLAssist](https://arxiv.org/abs/2407.13993) - Provides simple tools for automating literature reviews by leveraging Large Language Models and Natural Language Processing to extract information and evaluate relevance.
 - [ProfOlaf](https://arxiv.org/abs/2510.26750v2) - An open-source semi-automated tool designed to support systematic literature reviews by assisting in study selection and organization. 
 - [LatteReview](https://pouriarouzrokh.github.io/LatteReview/) - An open-source multi-agent framework designed to automate systematic review workflows using large language models.
+- [MedSci Skills](https://github.com/Aperivue/medsci-skills) - Open-source (MIT) Claude Code agent-skill suite for the medical research lifecycle: PubMed/CrossRef-verified reference checking, EQUATOR reporting-guideline and risk-of-bias auditing (PRISMA, STARD, QUADAS-2, ROBINS-I, and others), DTA and intervention meta-analysis synthesis, and PRISMA flow-diagram generation.
 - [EvidenceSynthesis](https://ohdsi.github.io/EvidenceSynthesis/) - Contains routines for combining causal effect estimates and study diagnostics across multiple data sites in a distributed study using meta-analysis.
 
 ## Visualization & Reporting


### PR DESCRIPTION
Adds **MedSci Skills** to **Workflow & Automation**, alongside the other LLM-based tools.

It is an open-source (MIT) Claude Code agent-skill suite for the medical research lifecycle, with capabilities directly relevant to evidence synthesis: PubMed/CrossRef-verified reference checking, EQUATOR reporting-guideline and risk-of-bias auditing (PRISMA, STARD, QUADAS-2, ROBINS-I, and others), DTA and intervention meta-analysis synthesis, and PRISMA flow-diagram generation.

Meets the inclusion criteria: OSI license (MIT), public repository, non-proprietary, reusable/extensible.

Repo: https://github.com/Aperivue/medsci-skills